### PR TITLE
002 Add Two Numbers: Remove floating point errors

### DIFF
--- a/python/002_Add_Two_Numbers.py
+++ b/python/002_Add_Two_Numbers.py
@@ -51,7 +51,7 @@ class Solution(object):
                 l2 = l2.next
             curr.next = ListNode(val % 10)
             curr = curr.next
-            carry = val / 10
+            carry = int(val / 10)
         if carry > 0:
             curr.next = ListNode(carry)
         return head.next


### PR DESCRIPTION
Fixes #55 -- I also got this error, I think it comes from inherent python floating point issues. This solution works so long as the inputs are integers (which according to the question, they should be)